### PR TITLE
Unescape strings

### DIFF
--- a/completions/license.fish
+++ b/completions/license.fish
@@ -1,13 +1,13 @@
-complete -c license -f -n "__fish_use_subcommand" -a mit
-complete -c license -f -n "__fish_use_subcommand" -a gpl-3.0
-complete -c license -f -n "__fish_use_subcommand" -a gpl-2.0
-complete -c license -f -n "__fish_use_subcommand" -a agpl-3.0
-complete -c license -f -n "__fish_use_subcommand" -a unlicense
-complete -c license -f -n "__fish_use_subcommand" -a apache-2.0
-complete -c license -f -n "__fish_use_subcommand" -a epl-1.0
-complete -c license -f -n "__fish_use_subcommand" -a bsd-2-clause
-complete -c license -f -n "__fish_use_subcommand" -a mpl-2.0
-complete -c license -f -n "__fish_use_subcommand" -a bsd-3-clause
-complete -c license -f -n "__fish_use_subcommand" -a lgpl-3.0
-complete -c license -f -n "__fish_use_subcommand" -a lgpl-2.1
-complete -c license -f -n "__fish_use_subcommand" -a wtfpl
+complete -c license -f -n "__fish_use_subcommand" -a "agpl-3.0\t'GNU Affero General Public License v3.0'
+apache-2.0\t'Apache License 2.0'
+bsd-2-clause\t'BSD 2-Clause \"Simplified\" License'
+bsd-3-clause\t'BSD 3-Clause \"New\" or \"Revised\" License'
+cc0-1.0\t'Creative Commons Zero v1.0 Universal'
+epl-2.0\t'Eclipse Public License 2.0'
+gpl-2.0\t'GNU General Public License v2.0'
+gpl-3.0\t'GNU General Public License v3.0'
+lgpl-2.1\t'GNU Lesser General Public License v2.1'
+lgpl-3.0\t'GNU Lesser General Public License v3.0'
+mit\t'MIT License'
+mpl-2.0\t'Mozilla Public License 2.0'
+unlicense\t'The Unlicense'"

--- a/functions/license.fish
+++ b/functions/license.fish
@@ -4,12 +4,12 @@ function license
 
   if test $argv[1]
     set -l license $argv[1]
-    set -l res (curl --silent --header $headers $base_url/$license | jq .'body')
-    echo -e $res | sed -e 's/^"//' -e 's/"$//'
+    set -l res (curl --silent --header $headers $base_url/$license | jq -r '.body' | string collect)
+    echo $res
   else
-    set -l res (curl --silent --header $headers $base_url)
+    set -l res (curl --silent --header $headers $base_url | jq -r '.[].key' | string collect)
     echo "Available Licenses: "
     echo
-    echo "$res" | jq .[].'key' | sed -e 's/^"//' -e 's/"$//'
+    echo $res
   end
 end


### PR DESCRIPTION
For me (latest version of fish, jq, most tools), the function returns with quotes messed up.

For example, `license mit` returns \\"Software\\" and \\"AS IS\\":
```
MIT License

Copyright (c) [year] [fullname]

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the \"Software\"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```

Use `jq -r` to write raw output and [string-collect](https://fishshell.com/docs/current/cmds/string-collect.html) to capture the multiline output in a fish variable.

This PR also updates the completions and adds descriptions.

<img width="669" alt="license-completions" src="https://user-images.githubusercontent.com/5209296/81366243-c6f76500-90af-11ea-9469-ba14952b7b7c.png">
